### PR TITLE
State reporting and errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,6 @@ The `name` key specifies which is a view and which is table, however the `value`
 ## Contributing
 We'll gladly accept any contributions as long as:
 1. Your changes are generic and not too specific to you (remember this serves many customers)
-1. You've added tests
-1. You've documented them
-1. It is backward compatible (if its not backward compatible use the `source.version` parameter to determine behaviour and contact us to coordinate)
+2. You've added tests
+3. You've documented them
+4. It is backward compatible (if its not backward compatible use the `source.version` parameter to determine behaviour and contact us to coordinate)

--- a/postgres/source.py
+++ b/postgres/source.py
@@ -38,7 +38,7 @@ class Postgres(panoply.DataSource):
 
         # if there is no cursor (starting a new table read), create it
         if not self.cursor:
-            self.conn, self.cursor = connect(self.source, self.log)
+            self.conn, self.cursor = connect(self.source)
             q = get_query(schema, table, self.source)
             self.execute('DECLARE cur CURSOR FOR {}'.format(q))
 
@@ -93,7 +93,7 @@ class Postgres(panoply.DataSource):
             WHERE table_schema NOT IN ('information_schema', 'pg_catalog')
         '''
 
-        self.conn, self.cursor = connect(self.source, self.log)
+        self.conn, self.cursor = connect(self.source)
         self.execute(query)
         result = map(format_table_name, self.cursor.fetchall())
 
@@ -107,7 +107,7 @@ class Postgres(panoply.DataSource):
         self.state(self.state_id, state)
 
 
-def connect(source, log):
+def connect(source):
     '''connect to the DB using properties from the source'''
     host, dbname = source['addr'].rsplit('/', 1)
     port = 5432

--- a/postgres/source.py
+++ b/postgres/source.py
@@ -72,7 +72,7 @@ class Postgres(panoply.DataSource):
         # Add __schemaname and __tablename to each row so it would be available
         # as `destination` parameter if needed and also in case multiple tables
         # are pulled into the same destination table.
-        # State_id is also added in order to support checkpoints
+        # state_id is also added in order to support checkpoints
         internals = dict(
             __tablename=table,
             __schemaname=schema,

--- a/postgres/source.py
+++ b/postgres/source.py
@@ -7,9 +7,10 @@ import backoff
 
 DEST = '{__tablename}'
 BATCH_SIZE = 5000
-CONNECT_TIMEOUT = 15 # seconds
+CONNECT_TIMEOUT = 15  # seconds
 MAX_RETRIES = 5
 RETRY_TIMEOUT = 2
+
 
 def _log_backoff(details):
     err = sys.exc_info()[1]
@@ -19,6 +20,7 @@ def _log_backoff(details):
         err.pgcode or '',
         err.message
     )
+
 
 # Used for testing - this constant is overriden durring tests so that we don't
 # actually have to wait for the retry

--- a/postgres/source.py
+++ b/postgres/source.py
@@ -20,8 +20,14 @@ def _log_backoff(details):
         err.message
     )
 
+# Used for testing - this constant is overriden durring tests so that we don't
+# actually have to wait for the retry
+def _get_connect_timeout():
+    return CONNECT_TIMEOUT
+
 
 class Postgres(panoply.DataSource):
+
     def __init__(self, *args, **kwargs):
         super(Postgres, self).__init__(*args, **kwargs)
 
@@ -40,7 +46,7 @@ class Postgres(panoply.DataSource):
                           psycopg2.DatabaseError,
                           max_tries=MAX_RETRIES,
                           on_backoff=_log_backoff,
-                          base=RETRY_TIMEOUT)
+                          base=_get_connect_timeout)
     def read(self, batch_size=None):
         batch_size = self.batch_size or BATCH_SIZE
         total = len(self.tables)

--- a/postgres/source.py
+++ b/postgres/source.py
@@ -101,7 +101,7 @@ class Postgres(panoply.DataSource):
         return result
 
     def _report_state(self, params, loaded):
-        table_name = '%(__schemaname)s_%(__tablename)s' % params
+        table_name = '%(__schemaname)s.%(__tablename)s' % params
         state = dict([(table_name, loaded)])
         self.state(self.state_id, state)
 
@@ -141,7 +141,7 @@ def get_query(schema, table, src):
         where = " WHERE {} > '{}'".format(src['inckey'], src['incval'])
 
     state = src.get('state') or {}
-    table_state = state.get("%s_%s" % (schema, table))
+    table_state = state.get("%s.%s" % (schema, table))
     if state and table_state:
         offset = " OFFSET %s" % table_state
 

--- a/postgres/source.py
+++ b/postgres/source.py
@@ -14,6 +14,7 @@ class Postgres(panoply.DataSource):
 
         self.source['destination'] = self.source.get('destination') or DEST
 
+        self.batch_size = self.source.get('__batchSize', None)
         tables = self.source.get('tables', [])
         self.tables = tables[:]
         self.index = 0

--- a/postgres/source.py
+++ b/postgres/source.py
@@ -6,6 +6,7 @@ import psycopg2.extras
 
 DEST = '{__tablename}'
 BATCH_SIZE = 5000
+CONNECT_TIMEOUT = 15 # seconds
 
 
 class Postgres(panoply.DataSource):
@@ -120,7 +121,8 @@ def connect(source, log):
             port=port,
             user=source['user'],
             password=source['password'],
-            dbname=dbname
+            dbname=dbname,
+            connect_timeout=CONNECT_TIMEOUT
         )
         cur = conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor)
     except psycopg2.OperationalError, e:

--- a/postgres/source.py
+++ b/postgres/source.py
@@ -18,8 +18,10 @@ class Postgres(panoply.DataSource):
         self.index = 0
         self.conn = None
         self.cursor = None
+        self.batch_size = self.source.get('__batchSize', None)
 
-    def read(self, n=BATCH_SIZE):
+    def read(self, batch_size=None):
+        batch_size = self.batch_size or BATCH_SIZE
         total = len(self.tables)
         if self.index >= total:
             return None  # no tables left, we're done
@@ -37,7 +39,7 @@ class Postgres(panoply.DataSource):
             self.execute('DECLARE cur CURSOR FOR {}'.format(q))
 
         # read n(=BATCH_SIZE) records from the table
-        self.execute('FETCH FORWARD {} FROM cur'.format(n))
+        self.execute('FETCH FORWARD {} FROM cur'.format(batch_size))
         result = self.cursor.fetchall()
 
         # add __schemaname and __tablename to each row so it would be available

--- a/postgres/source.py
+++ b/postgres/source.py
@@ -126,11 +126,12 @@ def connect(source):
         )
         cur = conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor)
     except psycopg2.OperationalError, e:
-        log(e)
-        raise panoply.PanoplyException(
-            "Login failed for user: {}".format(source['user']),
-            retryable=False
-        )
+        if 'authentication failed' in e.message:
+            e = panoply.PanoplyException(
+                "Login failed for user: {}".format(source['user']),
+                retryable=False
+            )
+        raise e
 
     return conn, cur
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,8 @@ setup(
     url="http://panoply.io",
     install_requires=[
         "panoply-python-sdk==1.4.0",
-        "psycopg2==2.7.1"
+        "psycopg2==2.7.1",
+        "backoff==1.4.3"
     ],
     extras_require={
         "test": [

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name="panoply_postgres",
-    version="2.0.2",
+    version="2.1.0",
     description="Panoply Data Source for Postgres",
     author="Panoply Dev Team",
     author_email="support@panoply.io",

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     author_email="support@panoply.io",
     url="http://panoply.io",
     install_requires=[
-        "panoply-python-sdk==1.3.4",
+        "panoply-python-sdk==1.4.0",
         "psycopg2==2.7.1"
     ],
     extras_require={

--- a/test.py
+++ b/test.py
@@ -109,7 +109,7 @@ class TestPostgres(unittest.TestCase):
         execute_mock.assert_has_calls([mock.call(q)], True)
 
     @mock.patch("psycopg2.connect")
-    def test_connect_error_auth(self, mock_connect):
+    def test_connect_auth_error(self, mock_connect):
         inst = Postgres(self.source, OPTIONS)
         inst.tables = [{'value': 'schema.foo'}]
         msg = 'authentication failed'
@@ -118,7 +118,7 @@ class TestPostgres(unittest.TestCase):
             inst.get_tables()
 
     @mock.patch("psycopg2.connect")
-    def test_connect_not_auth_error(self, mock_connect):
+    def test_connect_other_error(self, mock_connect):
         inst = Postgres(self.source, OPTIONS)
         inst.tables = [{'value': 'schema.foo'}]
         msg = 'something unexpected'
@@ -186,7 +186,7 @@ class TestPostgres(unittest.TestCase):
         end = inst.read()
         self.assertEqual(end, None)
 
-    # Make sure that the state is reorted and that the
+    # Make sure that the state is reported and that the
     # output data contains a key __state
     @mock.patch("postgres.source.Postgres.state")
     @mock.patch("psycopg2.connect")

--- a/test.py
+++ b/test.py
@@ -18,6 +18,11 @@ class TestPostgres(unittest.TestCase):
             "inckey": "inckey",
             "incval": "incval"
         }
+        self.mock_recs = [
+            {'id': 1, 'col1': 'foo1', 'col2': 'bar1'},
+            {'id': 2, 'col1': 'foo2', 'col2': 'bar2'},
+            {'id': 3, 'col1': 'foo3', 'col2': 'bar3'}
+        ]
 
     def tearDown(self):
         self.source = None
@@ -60,18 +65,12 @@ class TestPostgres(unittest.TestCase):
         '''reads a table from the database and validates that each row
         has a __tablename and __schemaname column'''
 
-        mock_recs = [
-            {'id': 1, 'col1': 'foo1', 'col2': 'bar1'},
-            {'id': 2, 'col1': 'foo2', 'col2': 'bar2'},
-            {'id': 3, 'col1': 'foo3', 'col2': 'bar3'}
-        ]
-
         inst = Postgres(self.source, OPTIONS)
         inst.tables = [{'value': 'my_schema.foo_bar'}]
-        m.return_value.cursor.return_value.fetchall.return_value = mock_recs
+        m.return_value.cursor.return_value.fetchall.return_value = self.mock_recs
 
         rows = inst.read()
-        self.assertEqual(len(rows), len(mock_recs))
+        self.assertEqual(len(rows), len(self.mock_recs))
         for x in range(0, len(rows)):
             self.assertEqual(rows[x]['__tablename'], 'foo_bar')
             self.assertEqual(rows[x]['__schemaname'], 'my_schema')
@@ -159,19 +158,13 @@ class TestPostgres(unittest.TestCase):
         '''reads the entire table from the database and validates that the
         stream returns None to indicate the end'''
 
-        mock_recs = [
-            {'id': 1, 'col1': 'foo1', 'col2': 'bar1'},
-            {'id': 2, 'col1': 'foo2', 'col2': 'bar2'},
-            {'id': 3, 'col1': 'foo3', 'col2': 'bar3'}
-        ]
-
         inst = Postgres(self.source, OPTIONS)
         inst.tables = [{'value': 'my_schema.foo_bar'}]
-        result_order = [mock_recs, []]
+        result_order = [self.mock_recs, []]
         m.return_value.cursor.return_value.fetchall.side_effect = result_order
 
         rows = inst.read()
-        self.assertEqual(len(rows), len(mock_recs))
+        self.assertEqual(len(rows), len(self.mock_recs))
 
         empty = inst.read()
         self.assertEqual(empty, [])


### PR DESCRIPTION
https://app.asana.com/0/116217933045123/509049357129766

These changes aim to improve the general stability of this data source by -

1. Ensuring there is a timeout for initial connections (currently set to 15  #seconds): https://github.com/panoplyio/source-postgres/pull/4/commits/302b6d7ff328f4538fc41ed4e9da944b368fe227
2. Implementing a backoff strategy for all queries (max of 5 retries): https://github.com/panoplyio/source-postgres/pull/4/commits/9c2326005c188a699bbafd36e1e2e20da9007201
3. Implementing checkpoints for this source: 
    - Reporting state: https://github.com/panoplyio/source-postgres/pull/4/commits/95d650d879c59ef057f13e296c71d1a6ed9e85ea 
    - Recovering from state: https://github.com/panoplyio/source-postgres/pull/4/commits/e4b1a46a26e0d8387dcb9f2740a3ccee372c6f90

In addition, the source now supports defining `__batchSize` as an attribute of the source properties. https://github.com/panoplyio/source-postgres/pull/4/commits/f388591e0b33e928946fc8bf88dcd29ab111ec4c and https://github.com/panoplyio/source-postgres/pull/4/commits/3a2529612396dda8355c4381f654f551c77f633e