### PR TITLE
Adhere to reported checkpoints and update the current loaded count

### DIFF
--- a/postgres/source.py
+++ b/postgres/source.py
@@ -43,6 +43,7 @@ class Postgres(panoply.DataSource):
         self.cursor = None
         self.state_id = None
         self.loaded = 0
+        self.saved_state = self.source.get('state', {})
 
     @backoff.on_exception(backoff.expo,
                           psycopg2.DatabaseError,
@@ -63,7 +64,9 @@ class Postgres(panoply.DataSource):
 
         if not self.cursor:
             self.conn, self.cursor = connect(self.source)
-            q = self._get_query(schema, table, self.source)
+            state = self.saved_state.get("%s.%s" % (schema, table))
+            self.loaded = state if state is not None else 0
+            q = get_query(schema, table, self.source, state)
             self.execute('DECLARE cur CURSOR FOR {}'.format(q))
 
         # read n(=BATCH_SIZE) records from the table
@@ -140,22 +143,6 @@ class Postgres(panoply.DataSource):
         table_name = '%(__schemaname)s.%(__tablename)s' % params
         self.state(self.state_id, {table_name: loaded})
 
-    def _get_query(self, schema, table, src):
-        '''return a SELECT query using properties from the source'''
-        offset = ''
-        where = ''
-        if src.get('inckey') and src.get('incval'):
-            where = " WHERE {} > '{}'".format(src['inckey'], src['incval'])
-
-        state = src.get('state', {})
-        table_state = state.get("%s.%s" % (schema, table))
-        if state and table_state:
-            offset = " OFFSET %s" % table_state
-            self.loaded = table_state
-
-        return 'SELECT * FROM "{}"."{}"{}{}'.format(schema, table, where, offset)
-
-
 
 def connect(source):
     '''connect to the DB using properties from the source'''
@@ -185,6 +172,17 @@ def connect(source):
 
     return conn, cur
 
+def get_query(schema, table, src, state=None):
+    '''return a SELECT query using properties from the source'''
+    offset = ''
+    where = ''
+    if src.get('inckey') and src.get('incval'):
+        where = " WHERE {} > '{}'".format(src['inckey'], src['incval'])
+
+    if state:
+        offset = " OFFSET %s" % state
+
+    return 'SELECT * FROM "{}"."{}"{}{}'.format(schema, table, where, offset)
 
 def format_table_name(row):
     '''format the table name with schema (and type if applicable)'''

--- a/postgres/source.py
+++ b/postgres/source.py
@@ -172,6 +172,7 @@ def connect(source):
 
     return conn, cur
 
+
 def get_query(schema, table, src, state=None):
     '''return a SELECT query using properties from the source'''
     offset = ''
@@ -183,6 +184,7 @@ def get_query(schema, table, src, state=None):
         offset = " OFFSET %s" % state
 
     return 'SELECT * FROM "{}"."{}"{}{}'.format(schema, table, where, offset)
+
 
 def format_table_name(row):
     '''format the table name with schema (and type if applicable)'''

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name="panoply_postgres",
-    version="2.1.0",
+    version="2.2.0",
     description="Panoply Data Source for Postgres",
     author="Panoply Dev Team",
     author_email="support@panoply.io",

--- a/test.py
+++ b/test.py
@@ -229,6 +229,8 @@ class TestPostgres(unittest.TestCase):
         inst.read()
         first_query = mock_execute.call_args_list[0][0][0]
         self.assertTrue(first_query.endswith('OFFSET %s' % table_offset))
+        # Three records were returned so the loaded count should be offset+3
+        self.assertEqual(inst.loaded, table_offset + len(self.mock_recs))
 
     @mock.patch("postgres.source.Postgres.execute")
     @mock.patch("psycopg2.connect")

--- a/test.py
+++ b/test.py
@@ -228,8 +228,9 @@ class TestPostgres(unittest.TestCase):
 
         inst.read()
         first_query = mock_execute.call_args_list[0][0][0]
+        # The query should use `OFFSET` to skip already collected data
         self.assertTrue(first_query.endswith('OFFSET %s' % table_offset))
-        # Three records were returned so the loaded count should be offset+3
+        # Three records were returned so the loaded count should be OFFSET + 3
         self.assertEqual(inst.loaded, table_offset + len(self.mock_recs))
 
     @mock.patch("postgres.source.Postgres.execute")


### PR DESCRIPTION
https://app.asana.com/0/41101186914227/526526022919532

The fix to this issue was to set the `self.loaded` variable, to the state value reported via the checkpoints. The actual query did use the `OFFSET` but the `self.loaded` property was initialized to to the number of returned results.