### PR TITLE
State reporting fixes

### DIFF
--- a/postgres/source.py
+++ b/postgres/source.py
@@ -45,6 +45,10 @@ class Postgres(panoply.DataSource):
         self.loaded = 0
         self.saved_state = self.source.get('state', {})
 
+        # Remove the state object from the source definition
+        # since it does not need to be saved on the source.
+        self.source.pop('state', None)
+
     @backoff.on_exception(backoff.expo,
                           psycopg2.DatabaseError,
                           max_tries=MAX_RETRIES,

--- a/postgres/source.py
+++ b/postgres/source.py
@@ -85,13 +85,14 @@ class Postgres(panoply.DataSource):
         )
         result = [dict(r, **internals) for r in result]
         self.loaded += len(result)
-        self._report_state(internals, self.loaded)
 
         # no more rows for this table, clear and proceed to next table
         if not result:
             self.close()
             self.index += 1
             self.loaded = 0
+        else:
+            self._report_state(internals, self.loaded)
 
         return result
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name="panoply_postgres",
-    version="2.2.1",
+    version="2.2.2",
     description="Panoply Data Source for Postgres",
     author="Panoply Dev Team",
     author_email="support@panoply.io",

--- a/test.py
+++ b/test.py
@@ -255,7 +255,7 @@ class TestPostgres(unittest.TestCase):
     def test_remove_state_from_source(self):
         ''' once extracted, the state object is removed from the source '''
 
-        state = { 'my_schema.foo_bar': 1 }
+        state = {'my_schema.foo_bar': 1}
         self.source['state'] = state
         inst = Postgres(self.source, OPTIONS)
 

--- a/test.py
+++ b/test.py
@@ -233,6 +233,18 @@ class TestPostgres(unittest.TestCase):
         # Three records were returned so the loaded count should be OFFSET + 3
         self.assertEqual(inst.loaded, table_offset + len(self.mock_recs))
 
+    def test_remove_state_from_source(self):
+        ''' once extracted, the state object is removed from the source '''
+
+        state = { 'my_schema.foo_bar': 1 }
+        self.source['state'] = state
+        inst = Postgres(self.source, OPTIONS)
+
+        # State object should have been extracted and saved on the stream
+        self.assertEqual(inst.saved_state, state)
+        # No state key should be inside the source definition
+        self.assertIsNone(inst.source.get('state', None))
+
     @mock.patch("postgres.source.Postgres.execute")
     @mock.patch("psycopg2.connect")
     def test_batch_size(self, mock_connect, mock_execute):


### PR DESCRIPTION
These changes fix an issue with state reporting. In the past, the very last batch of data was empty but a state_id was still reported. This meant that the source monitor was waiting for data to be processed that never actually arrived. The solution was to only report on the state of the source if some actual data is being returned.

---

Additionally, I have inserted a small change that will prevent the state from being saved on the actual source definition. Once the state object is extracted, it is saved in a local variable and removed from the source.