### PR TITLE
Fix cursor connection

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ install:
 script:
     - coverage run --source=. test.py
     - coverage report -m
-    - pep8 --format=pylint --count .
+    - pycodestyle --format=pylint --count .

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ install:
 script:
     - coverage run --source=. test.py
     - coverage report -m
-    - pycodestyle --format=pylint --count .
+    - pycodestyle --format=pylint --count test.py setup.py postgres

--- a/postgres/keystrategy.py
+++ b/postgres/keystrategy.py
@@ -1,0 +1,37 @@
+
+MIN_INDEXES = 1
+
+
+def primary_keys(keys):
+    return filter(lambda r: r.get('indisprimary'), keys)
+
+
+def unique_keys(keys, unique=True):
+    return indexes(keys, unique)
+
+
+def non_unique_keys(keys, unique=False):
+    return indexes(keys, unique)
+
+
+def indexes(keys, unique):
+    keys = filter(lambda r: r.get('indisunique') == unique, keys)
+
+    # Get indexes with multiple columns
+    multiple = filter(lambda r: r.get('indnatts') > MIN_INDEXES, keys)
+
+    if multiple:
+        # Get first column and find the other columns for this index
+        first = multiple[0].get('indexrelid')
+
+        return filter(lambda r: r.get('indexrelid') == first, multiple)
+
+    # Return first index
+    return keys[:1]
+
+
+KEY_STRATEGY = [
+    primary_keys,
+    unique_keys,
+    non_unique_keys
+]

--- a/postgres/source.py
+++ b/postgres/source.py
@@ -1,9 +1,10 @@
-import sys
+import backoff
 import panoply
-import uuid
 import psycopg2
 import psycopg2.extras
-import backoff
+import sys
+import uuid
+
 
 DEST = '{__tablename}'
 BATCH_SIZE = 5000

--- a/postgres/source.py
+++ b/postgres/source.py
@@ -110,6 +110,8 @@ class Postgres(panoply.DataSource):
                     SQL_GET_COLUMNS,
                     table
                 )[:1]
+
+            self.current_keys = key_strategy(self.current_keys)
             q = get_query(schema, table, self.source, self.current_keys, state)
             self.execute('DECLARE cur CURSOR FOR {}'.format(q))
 
@@ -249,7 +251,6 @@ def get_query(schema, table, src, keys, state=None):
     inckey = src.get('inckey')
     incval = src.get('incval')
     if keys:
-        keys = key_strategy(keys)
         keys = [key.get('attname') for key in keys]
         if inckey and inckey not in keys:
             keys.append(inckey)

--- a/postgres/source.py
+++ b/postgres/source.py
@@ -99,11 +99,17 @@ class Postgres(panoply.DataSource):
             state = self.saved_state.get('last_value', None)
 
             if not self.current_keys:
-                self.current_keys = self.get_table_metadata(SQL_GET_KEYS, table)
+                self.current_keys = self.get_table_metadata(
+                    SQL_GET_KEYS,
+                    table
+                )
 
             if not self.current_keys:
                 # Select first column if no pk, indexes found
-                self.current_keys = self.get_table_metadata(SQL_GET_COLUMNS, table)[:1]
+                self.current_keys = self.get_table_metadata(
+                    SQL_GET_COLUMNS,
+                    table
+                )[:1]
             q = get_query(schema, table, self.source, self.current_keys, state)
             self.execute('DECLARE cur CURSOR FOR {}'.format(q))
 
@@ -154,7 +160,7 @@ class Postgres(panoply.DataSource):
         self.log("DONE", query)
 
     def close(self):
-        '''close the connection, and clear everything'''
+        """close the connection, and clear everything"""
         if self.cursor:
             self.cursor.close()
         if self.conn:

--- a/postgres/source.py
+++ b/postgres/source.py
@@ -75,7 +75,7 @@ class Postgres(panoply.DataSource):
 
         state = source.get('state', {})
         self.index = state.get('last_index', 0)
-        self.max_value = state.get('max_value', None)
+        self.max_value = None
 
         # Remove the state object from the source definition
         # since it does not need to be saved on the source.
@@ -153,7 +153,7 @@ class Postgres(panoply.DataSource):
         else:
             last_row = result[-1]
             self._save_last_values(last_row)
-            self._report_state(self.index, self.max_value)
+            self._report_state(self.index)
 
         return result
 
@@ -247,10 +247,9 @@ class Postgres(panoply.DataSource):
             'last_value': last_value
         }
 
-    def _report_state(self, current_index, max_value):
+    def _report_state(self, current_index):
         state = {
-            'last_index': current_index,
-            'max_value': max_value
+            'last_index': current_index
         }
         self.state(self.state_id, state)
 

--- a/setup.py
+++ b/setup.py
@@ -2,19 +2,19 @@ from distutils.core import setup
 
 setup(
     name="panoply_postgres",
-    version="2.2.2",
+    version="2.3.2",
     description="Panoply Data Source for Postgres",
     author="Panoply Dev Team",
     author_email="support@panoply.io",
     url="http://panoply.io",
     install_requires=[
-        "panoply-python-sdk==1.4.0",
+        "panoply-python-sdk==1.6.0",
         "psycopg2==2.7.1",
         "backoff==1.4.3"
     ],
     extras_require={
         "test": [
-            "pep8==1.7.0",
+            "pycodestyle==2.5.0",
             "coverage==4.3.4",
             "mock==2.0.0"
         ]

--- a/test.py
+++ b/test.py
@@ -6,6 +6,7 @@ from collections import OrderedDict
 from postgres.source import (
     Postgres,
     connect,
+    get_incremental,
     get_query,
     key_strategy,
     SQL_GET_KEYS,
@@ -930,6 +931,28 @@ class TestPostgres(unittest.TestCase):
                    'ORDER BY id,inckey'
 
         self.assertEqual(args[0], expected)
+
+    def test_get_incremental_key_in_where(self):
+        where = ''
+        inckey = 'inckey'
+        incval = 1
+        max_value = 100
+
+        result = get_incremental(where, inckey, incval, max_value)
+        expected = "(inckey >= '1' AND inckey <= '100')"
+
+        self.assertEqual(result, expected)
+
+    def test_get_incremental_key_not_in_where(self):
+        where = "(inckey, id) >= ('1', '2)"
+        inckey = 'inckey'
+        incval = 1
+        max_value = 100
+
+        result = get_incremental(where, inckey, incval, max_value)
+        expected = "inckey <= '100'"
+
+        self.assertEqual(result, expected)
 
 
 if __name__ == "__main__":

--- a/test.py
+++ b/test.py
@@ -7,6 +7,7 @@ from postgres.source import (
     Postgres,
     connect,
     get_query,
+    key_strategy,
     SQL_GET_KEYS,
     SQL_GET_COLUMNS
 )
@@ -697,6 +698,7 @@ class TestPostgres(unittest.TestCase):
         table = 'test'
         source = {}
         keys = inst.get_table_metadata(SQL_GET_KEYS, table)
+        keys = key_strategy(keys)
         state = None
 
         result = get_query(schema, table, source, keys, state)
@@ -739,6 +741,7 @@ class TestPostgres(unittest.TestCase):
         table = 'test'
         source = {}
         keys = inst.get_table_metadata(SQL_GET_KEYS, table)
+        keys = key_strategy(keys)
         state = None
 
         result = get_query(schema, table, source, keys, state)
@@ -767,6 +770,7 @@ class TestPostgres(unittest.TestCase):
         table = 'test'
         source = {}
         keys = inst.get_table_metadata(SQL_GET_KEYS, table)
+        keys = key_strategy(keys)
         state = None
 
         result = get_query(schema, table, source, keys, state)

--- a/test.py
+++ b/test.py
@@ -374,7 +374,8 @@ class TestPostgres(unittest.TestCase):
 
         inst.read()
         first_query = mock_execute.call_args_list[0][0][0]
-        self.assertTrue("inckey >= 'incval' AND inckey <= '100'" in first_query)
+        self.assertTrue("inckey >= 'incval' AND inckey <= '100'" in
+                        first_query)
         self.assertTrue('FROM "public"."test2"' in first_query)
 
     def test_remove_state_from_source(self):

--- a/test.py
+++ b/test.py
@@ -315,7 +315,6 @@ class TestPostgres(unittest.TestCase):
         state_id = rows[0]['__state']
         state_obj = dict([
             ('last_index', 0),
-            ('max_value', 100)
         ])
 
         msg = 'State ID is not the same in all rows!'
@@ -382,16 +381,13 @@ class TestPostgres(unittest.TestCase):
     def test_remove_state_from_source(self):
         """ once extracted, the state object is removed from the source """
         last_index = 3
-        max_value = 100
         state = {
             'last_index': last_index,
-            'max_value': max_value
         }
         self.source['state'] = state
         inst = Postgres(self.source, OPTIONS)
 
         self.assertEqual(inst.index, last_index)
-        self.assertEqual(inst.max_value, max_value)
         # No state key should be inside the source definition
         self.assertIsNone(inst.source.get('state', None))
 

--- a/test.py
+++ b/test.py
@@ -44,7 +44,7 @@ class TestPostgres(unittest.TestCase):
     # fetches list of tables from database
     @mock.patch("psycopg2.connect")
     def test_get_tables(self, m):
-        '''gets the list of tables from the database'''
+        """gets the list of tables from the database"""
 
         # Notice 'name' here is only for validation of expected result.
         # It is not a field that returns in the actual query results
@@ -190,8 +190,8 @@ class TestPostgres(unittest.TestCase):
     @mock.patch("postgres.source.Postgres.execute")
     @mock.patch("psycopg2.connect")
     def test_read_end_stream(self, mock_connect, mock_execute, mock_metadata):
-        '''reads the entire table from the database and validates that the
-        stream returns None to indicate the end'''
+        """reads the entire table from the database and validates that the
+        stream returns None to indicate the end"""
         # TODO make it read two tables
         tables = [
             {'value': 'public.table1'},
@@ -280,7 +280,6 @@ class TestPostgres(unittest.TestCase):
         end = inst.read()
         self.assertEqual(end, None)
 
-
     # Make sure that the state is reported and that the
     # output data contains a key __state
     @mock.patch.object(Postgres, 'get_table_metadata',
@@ -288,8 +287,8 @@ class TestPostgres(unittest.TestCase):
     @mock.patch("postgres.source.Postgres.state")
     @mock.patch("psycopg2.connect")
     def test_reports_state(self, mock_connect, mock_state, _):
-        '''before returning a batch of data, the sources state should be
-        reported as well as having the state ID appended to each data object'''
+        """before returning a batch of data, the sources state should be
+        reported as well as having the state ID appended to each data object"""
 
         inst = Postgres(self.source, OPTIONS)
         table_name = 'my_schema.foo_bar'


### PR DESCRIPTION
[Asana Task](https://app.asana.com/0/854225875551651/1109940166618803/f)

### Description
- When the source encountered an error during `read`, the backoff mechanism does not start where it left off. I changed the source to retry where it left off.

### Changes made
- Use available pks, unique/non unique indexes for order by.
- Instead of recreating the cursor with offset, we will recreate the cursor based on the last value of the keys we use for order by. This is more efficient compared to using offset.

### Test
- Tested in my local environment by restarting `postgres` service
- Test schema

Please see Asana for more info.

### Note
- For `ORDER BY` to work the source should have incremental values. This fix will work for sources with incremental values.