### PR TITLE
Fixes support for case-sensitive tables

### DIFF
--- a/postgres/source.py
+++ b/postgres/source.py
@@ -235,7 +235,7 @@ class Postgres(panoply.DataSource):
         return result
 
     def get_table_metadata(self, sql, schema, table):
-        search_path = '{}.{}'.format(schema, table)
+        search_path = '"{}"."{}"'.format(schema, table)
         sql = sql.format(search_path)
         self.log(sql)
         self.execute(sql)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name="panoply_postgres",
-    version="2.3.4",
+    version="2.3.5",
     description="Panoply Data Source for Postgres",
     author="Panoply Dev Team",
     author_email="support@panoply.io",


### PR DESCRIPTION
[Asana Task](https://app.asana.com/0/1107836860704912/1132481757278780/f)

## Description

When a user has tables names in upper case, the query to get the keys fails to find the table, as the cast to [`regclass`](https://www.postgresql.org/docs/8.1/datatype-oid.html) implicitly searches for lower-case variations. (see https://stackoverflow.com/questions/56227815/is-there-a-way-to-use-regclass-in-a-case-sensitive-way for more information)

The solution to this problem is simply properly quoting the schema and table name, inside their `string` form before casting.

So instead of
```sql
SELECT 'schema.Table'::regclass;
```
we should be doing:
```sql
SELECT '"schema"."Table"'::regclass
```
