### PR TITLE
Allow connection parameters from address field

### DIFF
--- a/postgres/source.py
+++ b/postgres/source.py
@@ -260,19 +260,16 @@ class Postgres(panoply.DataSource):
 
 def connect(source):
     """connect to the DB using properties from the source"""
-    host, dbname = source['addr'].rsplit('/', 1)
-    port = 5432
-    if ':' in host:
-        host, port = host.rsplit(':', 1)
-        port = int(port)  # pyscopg expects port to be numeric
 
+    # create partial DSN, user & pass still supplied as kwargs
+    # as they're input separately from addr and will take precendence
+    # over any user/pass from addr
+    dsn = 'postgres://%s' % source['addr']
     try:
         conn = psycopg2.connect(
-            host=host,
-            port=port,
+            dsn=dsn,
             user=source['user'],
             password=source['password'],
-            dbname=dbname,
             connect_timeout=CONNECT_TIMEOUT
         )
         cur = conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name="panoply_postgres",
-    version="2.3.5",
+    version="2.3.6",
     description="Panoply Data Source for Postgres",
     author="Panoply Dev Team",
     author_email="support@panoply.io",

--- a/test.py
+++ b/test.py
@@ -223,6 +223,24 @@ class TestPostgres(unittest.TestCase):
             connect_timeout=postgres.source.CONNECT_TIMEOUT
         )
 
+    @mock.patch("psycopg2.connect")
+    def test_connection_parameters(self, mock_connect):
+        source = {
+            "addr": "test.database:5439/foobar?sslmode=verify-full",
+            "user": "test",
+            "password": "testpassword",
+            "tables": [{'value': 'schema.foo'}]
+        }
+        inst = Postgres(source, OPTIONS)
+        inst.read()
+
+        mock_connect.assert_called_with(
+            dsn="postgres://test.database:5439/foobar?sslmode=verify-full",
+            user=source['user'],
+            password=source['password'],
+            connect_timeout=postgres.source.CONNECT_TIMEOUT
+        )
+
     @mock.patch.object(Postgres, 'get_max_value', side_effect=mock_max_value)
     @mock.patch.object(Postgres, 'get_table_metadata')
     @mock.patch("postgres.source.Postgres.execute")

--- a/test.py
+++ b/test.py
@@ -188,7 +188,7 @@ class TestPostgres(unittest.TestCase):
             inst.get_tables()
 
     @mock.patch("psycopg2.connect")
-    def test_default_port(self, mock_connect):
+    def test_no_port(self, mock_connect):
         source = {
             "addr": "test.database.name/foobar",
             "user": "test",
@@ -199,11 +199,9 @@ class TestPostgres(unittest.TestCase):
         inst.read()
 
         mock_connect.assert_called_with(
-            host="test.database.name",
-            port=5432,
+            dsn="postgres://test.database.name/foobar",
             user=source['user'],
             password=source['password'],
-            dbname="foobar",
             connect_timeout=postgres.source.CONNECT_TIMEOUT
         )
 
@@ -219,11 +217,9 @@ class TestPostgres(unittest.TestCase):
         inst.read()
 
         mock_connect.assert_called_with(
-            host="test.database.name",
-            port=5439,
+            dsn="postgres://test.database.name:5439/foobar",
             user=source['user'],
             password=source['password'],
-            dbname="foobar",
             connect_timeout=postgres.source.CONNECT_TIMEOUT
         )
 


### PR DESCRIPTION
Previously the addr field was parsed and broken down into its
componenets which were then passed to pyscopg2.connect as kwargs

This method did not allow users to specify their own connection
parameters as they dropped by the parsing.

Instead we now build a DSN that is mostly user-defined (aside from the
scheme) - this will allow users to define any parameters they wish.
User and Password are still supplied as kwargs and will take precedences
over address provided values