### PR TITLE
Fix connection closing

### DIFF
--- a/postgresv2/utils.py
+++ b/postgresv2/utils.py
@@ -65,7 +65,7 @@ def close_connection(connector: Connector):
     try:
         if connector.cursor:
             connector.cursor.close()
-        if connector.connection:
+        if not connector.connection.closed:
             # psycopg2 uses transactions for everything, hence we use rollback
             # to cleanly exit the transaction although conn.close should do it
             # implicitly

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ required_packages = [
 
 setup(
     name="panoply_postgres",
-    version="3.0.1",
+    version="3.0.2",
     description="Panoply Data Source for Postgres",
     author="Panoply Dev Team",
     author_email="support@panoply.io",


### PR DESCRIPTION
Fix issue: `psycopg2.InterfaceError: connection already closed`
Because of which query was not retried