### PR TITLE
[DS - 1508] Postgres - use index to retry interrupted query

### DIFF
--- a/postgresv2/dal/key_strategy.py
+++ b/postgresv2/dal/key_strategy.py
@@ -1,0 +1,49 @@
+from copy import copy
+
+
+def primary_keys(keys: list):
+    return [element for element in keys if element['indisprimary']]
+
+
+def unique_keys(keys: list):
+    return get_index(keys, unique=True)
+
+
+def non_unique_keys(keys: list):
+    return get_index(keys, unique=False)
+
+
+def get_index(keys: list, unique: bool) -> list:
+    keys = [element for element in keys if element['indisunique'] == unique]
+    if not keys:
+        return
+
+    # Get first column and find the other columns for this index
+    first = keys[0]
+    multiple = first['indnatts'] > 1
+
+    if multiple:
+        # Find other columns for this index
+        return [element for element in keys
+                if element['indexrelid'] == first['indexrelid']]
+
+    return [first]
+
+
+KEY_STRATEGY = [
+    primary_keys,
+    unique_keys,
+    non_unique_keys
+]
+
+
+def choose_index(keys: list) -> list:
+    keys_copy = copy(keys)
+
+    for strategy in KEY_STRATEGY:
+        results = strategy(keys_copy)
+
+        if results:
+            ordered_index = sorted(results, key=lambda i: i['column_order'])
+            return [element['attname'] for element in ordered_index]
+    return []

--- a/postgresv2/dal/queries/consts.py
+++ b/postgresv2/dal/queries/consts.py
@@ -8,3 +8,22 @@ SQL_GET_ALL_TABLES = """
         SELECT * FROM information_schema.tables
         WHERE table_schema NOT IN ('information_schema', 'pg_catalog')
     """
+
+SQL_GET_INDEXES = """
+    SELECT a.attname,
+            i.indexrelid,
+           i.indnatts,
+           i.indisunique,
+           i.indisprimary,
+           (SELECT i
+            FROM (SELECT *,
+                         row_number()
+                         OVER () i
+                  FROM unnest(indkey) WITH ORDINALITY AS a(att_num)) a
+            WHERE att_num = attnum) as column_order
+    FROM pg_index i
+             JOIN pg_attribute a ON a.attrelid = i.indrelid
+        AND a.attnum = ANY (i.indkey)
+    WHERE i.indrelid = '{}'::regclass
+    order by i.indnatts;
+    """

--- a/postgresv2/exceptions.py
+++ b/postgresv2/exceptions.py
@@ -8,3 +8,7 @@ class PostgresInckeyError(Exception):
 
 class PostgresNoDataError(Exception):
     pass
+
+
+class PostgresUndefinedTableError(Exception):
+    pass

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ required_packages = [
 
 setup(
     name="panoply_postgres",
-    version="3.0.3",
+    version="3.0.4",
     description="Panoply Data Source for Postgres",
     author="Panoply Dev Team",
     author_email="support@panoply.io",


### PR DESCRIPTION
Jira issue: [DS-1508](https://panoply.atlassian.net/browse/DS-1508)
In case there was an issue with connection, after the retry the cursor was restarted from the beginning of table.
This change will add ordering on index and saving last value of each batch. So that if the query is terminated we will declare a new cursor starting from the last succeeded point.
In case there is no index, this logic won't be implemented, as ordering on unindexed column harms the performance.
If the inckey is set, it will be used as index.

Note: this logic is required for hot-standby servers as they have a time limitation on running queries that are defined on the user's side.